### PR TITLE
[WIP] [Consensus] Verify old MN sigs pre-hardfork

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -178,7 +178,7 @@ public:
         consensus.height_RHF = 1250000; // TODO: Decide Hardfork block height
         consensus.height_last_ZC_AccumCheckpoint = 231570;
         consensus.height_start_BIP65 = consensus.height_RHF;             // 82629b7a9978f5c7ea3f70a12db92633a7d2e436711500db28b97efd48b1e527
-        consensus.height_start_MessSignaturesV2 = 2153200;  // TimeProtocolV2, Blocks V7 and newMessageSignatures
+        consensus.height_start_MessSignaturesV2 = consensus.height_RHF;  // TimeProtocolV2, Blocks V7 and newMessageSignatures
         consensus.height_start_StakeModifierNewSelection = 1;
         consensus.height_start_StakeModifierV2 = consensus.height_RHF;
         consensus.height_start_TimeProtoV2 = consensus.height_RHF;       // TimeProtocolV2, Blocks V7 and newMessageSignatures

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -479,7 +479,7 @@ bool CMasternodeBroadcast::CheckSignature() const
                             );
 
     if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
-        // VerifyMessaged failed... let's check if this MN is using the old signature message format
+        // VerifyMessage failed... let's check if this MN is using the old signature message format
         if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, GetOldStrMessage(), strError))
             return error("%s : VerifyMessage (nMessVersion=%d) failed: %s", __func__, nMessVersion, strError);
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -442,7 +442,7 @@ bool CMasternodeBroadcast::Sign(const CKey& key, const CPubKey& pubKey, const bo
         strMessage = GetSignatureHash().GetHex();
     } else {
         nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        strMessage = GetStrMessage();
+        strMessage = GetOldStrMessage();
     }
 
     if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
@@ -478,10 +478,24 @@ bool CMasternodeBroadcast::CheckSignature() const
                             GetStrMessage()
                             );
 
-    if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError))
-        return error("%s : VerifyMessage (nMessVersion=%d) failed: %s", __func__, nMessVersion, strError);
+    if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
+        // VerifyMessaged failed... let's check if this MN is using the old signature message format
+        if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, GetOldStrMessage(), strError))
+            return error("%s : VerifyMessage (nMessVersion=%d) failed: %s", __func__, nMessVersion, strError);
+    }
 
     return true;
+}
+
+std::string CMasternodeBroadcast::GetOldStrMessage() const
+{
+    std::string strMessage;
+
+    std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
+    std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
+    strMessage = addr.ToString() + std::to_string(sigTime) + vchPubKey + vchPubKey2 + std::to_string(protocolVersion);
+
+    return strMessage;
 }
 
 bool CMasternodeBroadcast::CheckDefaultPort(std::string strService, std::string& strErrorRet, std::string strContext)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -316,6 +316,8 @@ public:
     bool Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs);
     bool Sign(const std::string strSignKey, const bool fNewSigs);
     bool CheckSignature() const;
+    // for compatability with pre-v2.0 masternode messages
+    std::string GetOldStrMessage() const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -316,7 +316,7 @@ public:
     bool Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs);
     bool Sign(const std::string strSignKey, const bool fNewSigs);
     bool CheckSignature() const;
-    // for compatability with pre-v2.0 masternode messages
+    // for compatibility with pre-v2.0 masternode messages
     std::string GetOldStrMessage() const;
 
     ADD_SERIALIZE_METHODS;


### PR DESCRIPTION
This PR intends to add backwards-compatability for MN signatures on the previous ZENZO Core network (from v1.0.0 to v1.3.1).

ZENZO Core v2.0 is a fork of PIVX v4.1, more than ~3 years ahead of ZENZO Core v1.3.1's PIVX-forked codebase, meaning v2.0 doesn't have the capability to sign/verify old masternode messages, and would accidently fork/cause issues when setting up v2.0 masternodes pre-hardfork.

Before the hardfork, ZENZO Core v2.0 with this PR added; should continue to use the old v1.3.1-compatible masternode messages.
After the hardfork, the network should switch to `MESS_VER_HASH` masternode messages, the latest format.

Reference: [This PIVX Commit](https://github.com/PIVX-Project/PIVX/pull/1001/files) removes the old message compatability, and this PR adds these back into the codebase.

---
#### I'm still relatively new to Core development (and C++) so developer reviews are *necessary* to merge this. ZNZ tips will be granted to any code reviews, just post your address along with the review, thank you!