### PR TITLE
[Consensus] Reverse-Hardfork Improvements

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -71,7 +71,7 @@ CBlockIndex::CBlockIndex(const CBlock& block):
         nNonce{block.nNonce}
 {
     ClearMapZcSupply();
-    if(block.nVersion > 3 && block.nVersion < 7)
+    if (block.nVersion == 4)
         nAccumulatorCheckpoint = block.nAccumulatorCheckpoint;
     if (block.IsProofOfStake())
         SetProofOfStake();
@@ -122,7 +122,7 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
     block.nTime = nTime;
     block.nBits = nBits;
     block.nNonce = nNonce;
-    if (nVersion > 3 && nVersion < 7) block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
+    if (nVersion == 4) block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
     return block;
 }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -328,9 +328,9 @@ public:
             READWRITE(nTime);
             READWRITE(nBits);
             READWRITE(nNonce);
-            if(this->nVersion > 3) {
+            if (this->nVersion > 3) {
                 READWRITE(mapZerocoinSupply);
-                if(this->nVersion < 7) READWRITE(nAccumulatorCheckpoint);
+                if (this->nVersion == 4) READWRITE(nAccumulatorCheckpoint);
             }
 
         } else {
@@ -381,7 +381,7 @@ public:
         block.nTime = nTime;
         block.nBits = nBits;
         block.nNonce = nNonce;
-        if (nVersion > 3 && nVersion < 7)
+        if (nVersion == 4)
             block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
         return block.GetHash();
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -61,7 +61,7 @@ struct Params {
     uint256 ProofOfStakeLimit(const bool fV2) const { return fV2 ? posLimitV2 : posLimitV1; }
     bool MoneyRange(const CAmount& nValue) const { return (nValue >= 0 && nValue <= nMaxMoneyOut); }
     bool IsMessSigV2(const int nHeight) const { return nHeight >= height_start_MessSignaturesV2; }
-    bool IsPastRHFBlock(const int nHeight) const {return nHeight >height_RHF; }
+    bool IsPastRHFBlock(const int nHeight) const {return nHeight >= height_RHF; }
     bool IsTimeProtocolV2(const int nHeight) const { return nHeight >= height_start_TimeProtoV2; }
     bool IsStakeModifierV2(const int nHeight) const { return nHeight >= height_start_StakeModifierV2; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3716,9 +3716,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     // Reject outdated version blocks
     if ((block.nVersion < 3 && nHeight >= 1) ||
         (block.nVersion < 4 && nHeight >= consensus.height_start_ZC) ||
-        (block.nVersion < 5 && nHeight >= consensus.height_start_BIP65) ||
-        (block.nVersion < 6 && nHeight >= consensus.height_start_StakeModifierV2) ||
-        (block.nVersion < 7 && nHeight >= consensus.height_start_TimeProtoV2))
+        (block.nVersion < 5 && nHeight >= consensus.height_RHF))
     {
         std::string stringErr = strprintf("rejected block version %d at height %d", block.nVersion, nHeight);
         return state.Invalid(error("%s : %s", __func__, stringErr), REJECT_OBSOLETE, stringErr);

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -18,7 +18,7 @@ uint256 CBlockHeader::GetHash() const
     if (nVersion < 4)
         return XEVAN(BEGIN(nVersion), END(nNonce));
 
-    if (nVersion < 7)
+    if (nVersion == 4)
         return Hash(BEGIN(nVersion), END(nAccumulatorCheckpoint));
 
     return Hash(BEGIN(nVersion), END(nNonce));

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,14 +23,14 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=4;     //!> Version 7 removes nAccumulatorCheckpoint from serialization
+    static const int32_t CURRENT_VERSION = 5;     //!> Version 5 marks ZENZO reverse-hardfork blocks (Adds: PoS v2, Time Proto, CLTV, etc - Removes: Accumulator)
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
-    uint256 nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
+    uint256 nAccumulatorCheckpoint;             // only for version 4.
 
     CBlockHeader()
     {
@@ -50,7 +50,7 @@ public:
         READWRITE(nNonce);
 
         //zerocoin active, header changes to include accumulator checksum
-        if(nVersion > 3 && nVersion < 7)
+        if (nVersion == 4)
             READWRITE(nAccumulatorCheckpoint);
     }
 
@@ -131,7 +131,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
-        if(nVersion > 3 && nVersion < 7)
+        if (nVersion == 4)
             block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
         return block;
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -244,11 +244,13 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nStatus = diskindex.nStatus;
                 pindexNew->nTx = diskindex.nTx;
 
-                //zerocoin
+                // Zerocoin
+                // is 'nAccumulatorCheckpoint' needed on version 5 blocks?
+                // Can we add 'if (pindexNew->nVersion == 4)' here?
                 pindexNew->nAccumulatorCheckpoint = diskindex.nAccumulatorCheckpoint;
                 pindexNew->mapZerocoinSupply = diskindex.mapZerocoinSupply;
 
-                //Proof Of Stake
+                // Proof Of Stake
                 pindexNew->nMoneySupply = diskindex.nMoneySupply;
                 pindexNew->nFlags = diskindex.nFlags;
                 pindexNew->vStakeModifier = diskindex.vStakeModifier;


### PR DESCRIPTION
This PR contains core improvements to the Reverse-Hardfork code implemented by Akshaynexus.

**Changes:**
- Hardfork block version (`nVersion`) changed from **7** to **5** (To increment the block version, instead of *jumping* from 4 to 7).
- Accumulator `block` + `header` logic changes (Accumulators **only** existed on block version 4, *not* a range of block versions).
- Miner changes: Accumulator is taken from `pindexPrev` *only* on block version **4**.

---
Reviews are __heavily__ appreciated!